### PR TITLE
fix(license): relicense project according to npm policy

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,16 @@
-To the extent possible under law, maintainers for this project have waived all copyright and related or neighboring rights to this project.
+ISC License
 
-For more information on this waiver, see: https://creativecommons.org/publicdomain/zero/1.0/
+Copyright (c) npm, Inc.
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, provided that the
+above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE COPYRIGHT HOLDER DISCLAIMS
+ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "email": "kzm@sykosomatic.org",
     "twitter": "maybekatz"
   },
-  "license": "CC0-1.0",
+  "license": "ISC",
   "dependencies": {
     "npm-package-arg": "^5.1.2",
     "semver": "^5.3.0"


### PR DESCRIPTION
BREAKING CHANGE: This moves the license from CC0 to ISC and properly documents the copyright as belonging to npm, Inc.