### PR TITLE
feat(errors): Add valid targets to ETARGET message

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,12 @@ function pickManifest (packument, wanted, opts) {
   const manifest = target && packument.versions[target]
   if (!manifest) {
     err = new Error(
-      `No matching version found for ${packument.name}@${wanted}`
+      `No matching version found for ${packument.name}@${wanted}\n` +
+      `Valid install targets:\n  ${
+        Object.keys(distTags).concat(
+          !opts.includeDeprecated ? undeprecated : versions
+        ).join(', ')
+      }`
     )
     err.code = 'ETARGET'
     err.name = packument.name

--- a/index.js
+++ b/index.js
@@ -109,7 +109,8 @@ function pickManifest (packument, wanted, opts) {
       `Valid install targets:\n  ${
         Object.keys(distTags).concat(
           !opts.includeDeprecated ? undeprecated : versions
-        ).join(', ')`
+        ).join(', ')
+      }`
     )
     err.code = 'ETARGET'
     err.name = packument.name

--- a/test/index.js
+++ b/test/index.js
@@ -97,6 +97,29 @@ test('errors if a non-registry spec is provided', t => {
   t.done()
 })
 
+test('includes available versions in ETARGET message', t => {
+  const metadata = {
+    'dist-tags': {
+      foo: '1.0.1',
+      latest: '1.0.0'
+    },
+    versions: {
+      '1.0.0': { version: '1.0.0' },
+      '1.0.1': { version: '1.0.1' },
+      '1.0.2': { version: '1.0.2', deprecated: 'yes' }
+    }
+  }
+  t.throws(() => {
+    pickManifest(metadata, '^2.0.0')
+  }, /\s{2}foo, latest, 1.0.0, 1.0.1$/)
+  t.throws(() => {
+    pickManifest(metadata, '^2.0.0', {
+      includeDeprecated: true
+    })
+  }, /\s{2}foo, latest, 1.0.0, 1.0.1, 1.0.2$/)
+  t.done()
+})
+
 test('skips any invalid version keys', t => {
   // Various third-party registries are prone to having trash as
   // keys. npm simply skips them. Yay robustness.


### PR DESCRIPTION
This includes all dist-tags and undeprecated versions by default.
The output respects the `{includeDeprecated: true}` option.

Fixes: #1